### PR TITLE
Fix issue with <section> where padding causes overlap other elements

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -57,9 +57,9 @@ const Banner = styled.div`
     > section {
       position: absolute;
       top: 0;
-      left: 0;
-      height: 100%;
-      max-width: 100%;
+      right: 0;
+      bottom: 0;
+      left: 0; 
 
       display: flex;
       align-items: center;


### PR DESCRIPTION
`<section>` elements overlap the elements below due to height/width 100% and padding. You can use `left: 0; right: 0; bottom: 0; top: 0;` to get the same effect, but without taking padding into account.

Screenshot of the issue:

![image](https://user-images.githubusercontent.com/3949335/31321296-ae2d892a-ac7b-11e7-9e8d-315522739954.png)
